### PR TITLE
Fix deploy: pass REACT_APP_API_URL directly to yarn build

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -18,7 +18,7 @@ else
   exit 1
 fi
 
-CI=true yarn build
+REACT_APP_API_URL=$REACT_APP_API_URL yarn build
 
 
 echo "###################################"


### PR DESCRIPTION
CircleCI seems to load every new process in some sort of sandbox, so the environment variables don't seem to be passed through unless we explicitly set them either in the command itself, the circleci/config.yml, or in circle ci's repo settings.