### PR TITLE
Updated update-member request to send params using the new format

### DIFF
--- a/src/components/MemberEdit.js
+++ b/src/components/MemberEdit.js
@@ -40,13 +40,14 @@ export class MemberEdit extends Component<Props, *> {
     const { id, email } = this.props.member;
     this.setState(state => ({ ...state, updating: true }));
     this.api
-      .updateMember(id, { email, ...this.state.updatedMember })
+      .updateMember(id, email, this.state.updatedMember)
       .then(() => this.props.onUpdate(this.state.updatedMember))
       .then(() => this.setState({ updating: false, updatedMember: {} }))
-      .then(
-        () => toast.success('Member updated successfully'),
-        () => toast.error('Error updating member')
-      );
+      .then(() => toast.success('Member updated successfully'))
+      .catch(error => {
+        toast.error('Error updating member');
+        console.log(error);
+      });
   }
 
   unsubscribeMember = e => {
@@ -109,7 +110,6 @@ export class MemberEdit extends Component<Props, *> {
                   placeholder="example@example.com"
                   defaultValue={member.email}
                   required
-                  disabled
                   title="Email edits are temporarily disabled"
                   onChange={({ target }) =>
                     this.onChange({ email: target.value })

--- a/src/libs/api-service.js
+++ b/src/libs/api-service.js
@@ -45,8 +45,12 @@ export default class ApiService {
     );
   }
 
-  updateMember(id, updatedMember) {
-    return this.client.put(`/members/${id}/`, updatedMember);
+  updateMember(id, email, params) {
+    const payload = {
+      email: email,
+      member: params,
+    };
+    return this.client.put(`/members/${id}/`, payload);
   }
 
   fetchBraintreeData(email: string) {


### PR DESCRIPTION
I'm getting an error when updating the member, and I don't understand how or why it's happening. The request is successful, I can see that on the Network logs on Chrome, but for some reason the Axios client is rejecting the promise with "Network Error". I'm also getting this cors error on the console: 
```
14220077:1 Failed to load https://yzmx1z67ge.execute-api.us-east-1.amazonaws.com/rodri/members/14220077/: No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://localhost:3000' is therefore not allowed access.
```
Which is weird since we're not triggering that request after an update, and also, why do we get a cors error if it's working when that same requests is made while initially loading the page? 

I'd appreciate another pair of eyes taking a look at this. 

**UPDATE:** Tuuli just helped me realize what the issue is, it's on the backend side. 