### PR TITLE
Display created at instead of start date for GC subscriptions

### DIFF
--- a/src/components/Subscriptions/SubscriptionItem.js
+++ b/src/components/Subscriptions/SubscriptionItem.js
@@ -11,7 +11,7 @@ interface SubscriptionView {
   provider: 'braintree' | 'gocardless';
   amount: number;
   currency: string;
-  startDate: string;
+  createdAt: string;
   endDate?: string;
   // FIXME: canceled typo?
   status: 'active' | 'canceled' | 'cancelled';
@@ -85,7 +85,7 @@ export default class SubscriptionItem extends Component<Props, State> {
     return this.renderSubscription({
       id: s.id,
       provider: s.provider,
-      startDate: s.createdAt,
+      createdAt: s.createdAt,
       amount: s.amount,
       currency: s.currency,
       status: s.status,
@@ -96,7 +96,7 @@ export default class SubscriptionItem extends Component<Props, State> {
     return this.renderSubscription({
       id: s.id,
       provider: s.provider,
-      startDate: s.startDate,
+      createdAt: s.createdAt,
       amount: s.amount,
       currency: s.currency,
       status: s.status,
@@ -115,23 +115,23 @@ export default class SubscriptionItem extends Component<Props, State> {
           <div className="SubscriptionItem-status level-item">
             {this.renderStatusIcon(data.status)}
           </div>
+          <div className="SubscriptionItem-cancel level-item">
+            {data.status === 'active' && this.renderCancelButton()}
+          </div>
           <div className="SubscriptionItem-provider level-item is-hidden-mobile">
             {data.provider}
           </div>
           <div className="level-item">
-            <code>{data.id}</code>
-          </div>
-          <div className="level-item">
             {this.renderAmount(data.amount, data.currency)}
+          </div>
+          <div className="SubscriptionItem-date level-item has-text-right has-text-grey">
+            {this.renderDate(data.createdAt)}
           </div>
         </div>
 
         <div className="level-right">
-          <div className="SubscriptionItem-date level-item has-text-right has-text-grey">
-            {this.renderDate(data.startDate)}
-          </div>
-          <div className="SubscriptionItem-cancel level-item">
-            {data.status === 'active' && this.renderCancelButton()}
+          <div className="level-item">
+            <code>{data.id}</code>
           </div>
         </div>
       </div>


### PR DESCRIPTION
The start date can be in the future, which is confusing, and can be locked into a specific date (e.g. GDP gets charged on 20th), so can be difficult to match a recurring donation "made yesterday" by its start date. 

I also changed the order of elements in the recurring donations table to put the resource IDs on a less prominent place, per Shonna's request.

![recurring_donations_layout](https://user-images.githubusercontent.com/6524052/35270793-72ce9974-0030-11e8-8d69-6b281092031d.png)
